### PR TITLE
dev dependencies should not be peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,6 @@
     "type": "git",
     "url": "https://github.com/twilio/twilio-node.git"
   },
-  "peerDependencies": {
-    "@types/express": "^4.17.7",
-    "@types/qs": "6.9.4"
-  },
   "dependencies": {
     "axios": "^0.21.1",
     "dayjs": "^1.8.29",


### PR DESCRIPTION
think the solution to https://github.com/twilio/twilio-node/issues/429 needed to go further, in yarn 2 i get:

```
➤ YN0002: │ server@workspace:server doesn't provide @types/express (pd7e11), requested by twilio
➤ YN0002: │ server@workspace:server doesn't provide @types/qs (p39eb1), requested by twilio
```